### PR TITLE
Issue #2: 404 on reload

### DIFF
--- a/mmda-frontend/nginx-mmda.conf
+++ b/mmda-frontend/nginx-mmda.conf
@@ -14,6 +14,8 @@ server {
     ssl_certificate_key     /certs/letsencrypt/live/corpora.linguistik.uni-erlangen.de/privkey.pem;
     ssl_trusted_certificate /certs/letsencrypt/live/corpora.linguistik.uni-erlangen.de/chain.pem;
 
+    rewrite ^/([a-z0-9]+/?)+$ /index.html;
+
     location / {
         try_files $uri $uri/ =404;
     }

--- a/mmda-frontend/nginx-mmda.conf
+++ b/mmda-frontend/nginx-mmda.conf
@@ -14,6 +14,7 @@ server {
     ssl_certificate_key     /certs/letsencrypt/live/corpora.linguistik.uni-erlangen.de/privkey.pem;
     ssl_trusted_certificate /certs/letsencrypt/live/corpora.linguistik.uni-erlangen.de/chain.pem;
 
+    # The SPA uses client side routing (see: router.js). Therefore we need to redirect all requests to index.html which match those routes.
     rewrite ^/([a-z0-9]+/?)+$ /index.html;
 
     location / {

--- a/mmda-frontend/public/fonts.css
+++ b/mmda-frontend/public/fonts.css
@@ -3,14 +3,14 @@
   font-family: 'Material Icons';
   font-style: normal;
   font-weight: 400;
-  src: url('fonts/Material.woff2') format('woff2');
+  src: url('/fonts/Material.woff2') format('woff2');
 }
 /* latin-ext */
 @font-face {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 300;
-  src: local('Roboto Light'), local('Roboto-Light'), url('fonts/Roboto-Light.ttf') format('truetype');
+  src: local('Roboto Light'), local('Roboto-Light'), url('/fonts/Roboto-Light.ttf') format('truetype');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -18,7 +18,7 @@
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 300;
-  src: local('Roboto Light'), local('Roboto-Light'), url('fonts/Roboto-Light.ttf') format('truetype');
+  src: local('Roboto Light'), local('Roboto-Light'), url('/fonts/Roboto-Light.ttf') format('truetype');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2212, U+2215;
 }
 /* latin-ext */
@@ -26,7 +26,7 @@
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 400;
-  src: local('Roboto'), local('Roboto-Regular'), url('fonts/Roboto-Regular.ttf') format('truetype');
+  src: local('Roboto'), local('Roboto-Regular'), url('/fonts/Roboto-Regular.ttf') format('truetype');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -34,7 +34,7 @@
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 400;
-  src: local('Roboto'), local('Roboto-Regular'), url('fonts/Roboto-Regular.ttf') format('truetype');
+  src: local('Roboto'), local('Roboto-Regular'), url('/fonts/Roboto-Regular.ttf') format('truetype');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2212, U+2215;
 }
 /* latin-ext */
@@ -42,7 +42,7 @@
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 500;
-  src: local('Roboto Medium'), local('Roboto-Medium'), url('fonts/Roboto-Medium.ttf') format('truetype');
+  src: local('Roboto Medium'), local('Roboto-Medium'), url('/fonts/Roboto-Medium.ttf') format('truetype');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -50,7 +50,7 @@
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 500;
-  src: local('Roboto Medium'), local('Roboto-Medium'), url('fonts/Roboto-Medium.ttf') format('truetype');
+  src: local('Roboto Medium'), local('Roboto-Medium'), url('/fonts/Roboto-Medium.ttf') format('truetype');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2212, U+2215;
 }
 /* latin-ext */
@@ -58,7 +58,7 @@
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 700;
-  src: local('Roboto Bold'), local('Roboto-Bold'), url('fonts/Roboto-Bold.ttf') format('truetype');
+  src: local('Roboto Bold'), local('Roboto-Bold'), url('/fonts/Roboto-Bold.ttf') format('truetype');
   unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+20A0-20AB, U+20AD-20CF, U+2C60-2C7F, U+A720-A7FF;
 }
 /* latin */
@@ -66,7 +66,7 @@
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 700;
-  src: local('Roboto Bold'), local('Roboto-Bold'), url('fonts/Roboto-Bold.ttf') format('truetype');
+  src: local('Roboto Bold'), local('Roboto-Bold'), url('/fonts/Roboto-Bold.ttf') format('truetype');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2212, U+2215;
 }
 


### PR DESCRIPTION
Fixes https://github.com/fau-klue/mmda-toolkit/issues/2

Nginx tries to serve a static file for a path that does not exist. E.g, when requesting `/analysis`, there is neither a `/analysis.html` nor `/analysis/index.html` to serve. The client however does manipulate the browser's history when navigating the app, so naturally on an actual page request, the app will break.

Therefore we can rewrite all requests that (reasonably) match the routes defined in [router.js](https://github.com/fau-klue/mmda-toolkit/blob/main/mmda-frontend/src/router/router.js) to `./index.html` so solve this issue.

This also requires the font import paths to be absolute. Otherwise the browser will fail to download if you load the application from any path other than `/` as can be seen on a development build.