### PR TITLE
Issue #3: Set CLR as default value for word cloud association measurement selections

### DIFF
--- a/mmda-frontend/src/components/Wordcloud/Sidebar/WordcloudCollocationParameters.vue
+++ b/mmda-frontend/src/components/Wordcloud/Sidebar/WordcloudCollocationParameters.vue
@@ -56,6 +56,9 @@ export default {
       this._setAM(this.am_value);
     },
   },
+  beforeMount() {
+    this._setAM('Conservative LR');
+  },
   mounted () {
     this.am_value = this.AM;
     this.selectWindow = this.windowSize;

--- a/mmda-frontend/src/components/WordcloudKeyword/Sidebar/WordcloudKeywordCollocationParameters.vue
+++ b/mmda-frontend/src/components/WordcloudKeyword/Sidebar/WordcloudKeywordCollocationParameters.vue
@@ -53,6 +53,9 @@ export default {
       this._setAM(this.am_value);
     },
   },
+  beforeMount() {
+    this._setAM('Conservative LR');
+  },
   mounted () {
     this.am_value = this.AM;
     this.selectWindow = this.windowSize;


### PR DESCRIPTION
Fixes https://github.com/fau-klue/mmda-toolkit/issues/3

The association measurement selection is bound to the Vuex store. That's one entry in the store which is basically shared by every instance of this component. For a quick fix (which is not very elegant, but probably sufficient until the app reaches its EOL :slightly_smiling_face: ), we can just update the store before the word cloud component mounts. That way CLR is set as default every time one navigates to a word cloud.