### PR TITLE
Issue #6: Reset pagination to page 1 on data update

### DIFF
--- a/mmda-frontend/src/components/Concordances/ConcordancesKeywordInContextList.vue
+++ b/mmda-frontend/src/components/Concordances/ConcordancesKeywordInContextList.vue
@@ -343,6 +343,7 @@ export default {
       downloadText("concordances.csv",this.csvFileText.replace(/"/g,"&quot;"));
     },
     update(){
+      this.pagination.page = 1
       //the required data (see setupIt) is available only after two ticks
       this.$nextTick(()=>this.$nextTick(()=>this.setupTableSize()));
     },


### PR DESCRIPTION
Fixes [issue #6 "concordancing: go pack to page 1"](https://github.com/fau-klue/mmda-toolkit/issues/6)

In order to reset the pagination, we can simply explicitly set it to `1` on the synced `pagination` object every time the `update()` method is called.