### PR TITLE
Issue #8: Prevent "keyword" table header content from overflowing its element

### DIFF
--- a/mmda-frontend/src/components/Concordances/ConcordancesKeywordInContextList.vue
+++ b/mmda-frontend/src/components/Concordances/ConcordancesKeywordInContextList.vue
@@ -156,6 +156,10 @@
   overflow: auto;
 }
 
+.no-overflow {
+  min-width: min-content;
+}
+
 </style>
 
 <script>
@@ -215,7 +219,7 @@ export default {
       return [
         { class:'kwic-id-head',text:'ID',value:'match_pos',align:'center'},
         { class:'kwic-context text-xs-right', align:"right", text:'... context', value:'reverse_head_text'},
-        { class:'kwic-keyword-head',align:'center', text:'keyword', value:'keyword.text'},
+        { class:'kwic-keyword-head no-overflow',align:'center', text:'keyword', value:'keyword.text'},
         { class:'kwic-context text-xs-left',align:'left', text:'context ...', value:'tail_text'},
         // ...this.useSentiment?[{text:"sentiment",value:'sentiment'}]:[]
       ];

--- a/mmda-frontend/src/components/ConcordancesKeyword/ConcordancesKeywordKWIC.vue
+++ b/mmda-frontend/src/components/ConcordancesKeyword/ConcordancesKeywordKWIC.vue
@@ -198,7 +198,7 @@ export default {
       return [
         { class:'kwic-id-head',text:'ID',value:'match_pos',align:'center'},
         { class:'kwic-context text-xs-right', align:"right", text:'... context', value:'reverse_head_text'},
-        { class:'kwic-keyword-head',align:'center', text:'keyword', value:'keyword.text'},
+        { class:'kwic-keyword-head no-overflow',align:'center', text:'keyword', value:'keyword.text'},
         { class:'kwic-context text-xs-left',align:'left', text:'context ...', value:'tail_text'},
       ];
     },


### PR DESCRIPTION
Fixes [issue #8 "concordancing: do not hide keyword"](https://github.com/fau-klue/mmda-toolkit/issues/8)

This CSS fix forces the element in question to always extend to (at least) its content's minimum width, thereby preventing the "keyword" header to be cut off.