### PR TITLE
Issue #9: Fix display of old constellation concordance lines

### DIFF
--- a/mmda-frontend/public/index.html
+++ b/mmda-frontend/public/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <title>mmda-frontend</title>
-    <link href="fonts.css" type="text/css" rel="stylesheet" />
+    <link href="<%= BASE_URL %>fonts.css" type="text/css" rel="stylesheet" />
   </head>
   <body>
     <noscript>

--- a/mmda-frontend/src/components/Constellation/ConstellationConcordances.vue
+++ b/mmda-frontend/src/components/Constellation/ConstellationConcordances.vue
@@ -40,7 +40,10 @@
           </v-form>
         </v-container>
 
-        <v-data-table v-if="filteredConcordances" :headers="concordanceHeaders" :items="filteredConcordances" :pagination.sync="concordancePagination" class="elevation-1">
+        <v-container v-if="isLoadingConcordances" class="text-lg-center">
+          <v-progress-circular indeterminate color="primary" class="align-self-center mx-auto" size="42"></v-progress-circular>
+        </v-container>
+        <v-data-table v-if="!isLoadingConcordances" :headers="concordanceHeaders" :items="filteredConcordances" :pagination.sync="concordancePagination" class="elevation-1">
           <template v-slot:items="props">
 
             <td class="text-xs-center">
@@ -59,14 +62,14 @@
               <template v-for="(el,idx) in props.item.text">
                 <span :key="'t_'+idx" @click="selectItem(el)" :class="'concordance '+ el.role " :style="el.style" :title="el.lemma">{{el.text}}</span>&#32;
               </template>
-            </td> 
+            </td>
           </template>
         </v-data-table>
 
       </v-tab-item>
     </v-tabs>
   </v-container>
- 
+
 </div>
 </template>
 
@@ -99,7 +102,7 @@ export default {
       {text: 'log likelihood', align: 'center', value: 'log_likelihood'},
       {text: 'Dice', align: 'center', value: 'dice'},
       {text: 'log ratio', align: 'center', value: 'log_ratio'},
-      {text: 'MI', align: 'center', value: 'mutual_information'},     
+      {text: 'MI', align: 'center', value: 'mutual_information'},
       {text: 'z-score', align: 'left', value: 'z_score'},
       {text: 't-score', align: 'left', value: 't_score'},
       {text: 'f', align: 'center', value: 'f'},
@@ -118,7 +121,13 @@ export default {
       concordances: 'constellation/concordances',
       associations: 'constellation/associations',
       discoursemes: 'constellation/discoursemes',
+      isLoadingConcordances: 'constellation/isLoadingConcordances',
     })
+  },
+  watch: {
+    concordances: function () {
+      this.filterConcordances()
+    }
   },
   methods: {
     ...mapActions({
@@ -144,7 +153,7 @@ export default {
       if(!this.filteredConcordances) return C;
       for(var ci of Object.keys(this.filteredConcordances)){
         var c = this.filteredConcordances[ci]
-        var r = { 
+        var r = {
           match_pos: ci,
           text: []
         };

--- a/mmda-frontend/src/components/Constellation/ConstellationConcordances.vue
+++ b/mmda-frontend/src/components/Constellation/ConstellationConcordances.vue
@@ -145,7 +145,8 @@ export default {
         }
         return a
       }
-      this.filteredConcordances = this.concordances.filter(checkDiscoursemes)
+      // account for this.concordances being null
+      this.filteredConcordances = this.concordances ? this.concordances.filter(checkDiscoursemes) : []
       this.filteredConcordances = this.formatConcordances()
     },
     formatConcordances () {

--- a/mmda-frontend/src/store/modules/constellation.js
+++ b/mmda-frontend/src/store/modules/constellation.js
@@ -209,7 +209,7 @@ const actions = {
   getConstellationConcordances ({commit}, data) {
     // Get Constellations discoursemes
     // In order to avoid displaying stale data, we clear the current constellation concordances before fetching new ones
-    commit('setConstellationConcordances', null)
+    commit('setConstellationConcordances', [])
     commit('setIsLoadingConcordances', true)
 
     return new Promise((resolve, reject) => {

--- a/mmda-frontend/src/store/modules/constellation.js
+++ b/mmda-frontend/src/store/modules/constellation.js
@@ -9,12 +9,14 @@ const state = {
   userConstellations: null,
   // One single constellation
   constellation: null,
+  // State of loading constellation concordances
+  isLoadingConcordances: false,
   // Constellation Concordances
   concordances: [],
   // Constellation Discoursemes
   discoursemes: [],
   // Constellation Associations
-  associations: []
+  associations: [],
 }
 
 const getters = {
@@ -32,7 +34,10 @@ const getters = {
   },
   associations (state) {
     return state.associations
-  }
+  },
+  isLoadingConcordances (state) {
+    return state.isLoadingConcordances
+  },
 }
 
 const actions = {
@@ -203,6 +208,10 @@ const actions = {
   },
   getConstellationConcordances ({commit}, data) {
     // Get Constellations discoursemes
+    // In order to avoid displaying stale data, we clear the current constellation concordances before fetching new ones
+    commit('setConstellationConcordances', null)
+    commit('setIsLoadingConcordances', true)
+
     return new Promise((resolve, reject) => {
 
       if (!data.username) return reject('No user provided')
@@ -220,6 +229,7 @@ const actions = {
       }
       api.get(`/user/${data.username}/constellation/${data.constellation_id}/concordance/`, request).then(function (response) {
         commit('setConstellationConcordances', response.data)
+        commit('setIsLoadingConcordances', false)
         resolve()
       }).catch(function (error) {
         reject(error)
@@ -240,6 +250,9 @@ const mutations = {
   setConstellationConcordances (state, concordances) {
     // List of Concordances: [{corpusName: concordances}]
     state.concordances = concordances
+  },
+  setIsLoadingConcordances (state, isLoading) {
+    state.isLoadingConcordances = isLoading
   },
   setConstellationSingle (state, constellation) {
     // One Constellation


### PR DESCRIPTION
Fixes #9 

Concordance lines are always stores in the vuex store and is never purged even if it becomes obsolete.
The solution is not elegant, but it mitigates the problem until v2:
* Whenever new concordance lines are loaded, the old data is replaced with an empty array
* To signify that data is being loaded, a flag is set which then conditionally renders a progress indicator instead of the data table
* The `ConstellationConcordances` component watches for changes of the `concordances` and applies its filters whenever such a change occurs (mostly: an API request with the latest concordances is being resolved when the component with the data table is visible to the user)

I noticed that the way the data fetching is generally designed at the moment, is prone to race conditions: very slowly resolved requests might cause trouble (i.e. overwrite more recent data), because they're never cancelled. Unfortunately I see no quick and easy fix for this issue at the moment.

To avoid annoyances during development I also included the fix for the faulty import of `fonts.css`. :sweat_smile: 