### PR TITLE
Issue #16: Fix sorting of concordance lines of previous context

### DIFF
--- a/mmda-frontend/src/components/Concordances/ConcordancesKeywordInContextList.vue
+++ b/mmda-frontend/src/components/Concordances/ConcordancesKeywordInContextList.vue
@@ -295,12 +295,7 @@ export default {
             }
           }
         }
-        r.head_text_last = (r
-          .head
-          // filter out elements that are not within the window
-          .filter(({ role }) => role === '')
-          .at(-1) || { text: '' })
-          .text.trim()
+        r.head_text_last = (r.head.at(-1) || { text: '' }).text.trim()
         C.push(r);
       }
 

--- a/mmda-frontend/src/components/Concordances/ConcordancesKeywordInContextList.vue
+++ b/mmda-frontend/src/components/Concordances/ConcordancesKeywordInContextList.vue
@@ -218,7 +218,7 @@ export default {
     headers () {
       return [
         { class:'kwic-id-head',text:'ID',value:'match_pos',align:'center'},
-        { class:'kwic-context text-xs-right', align:"right", text:'... context', value:'reverse_head_text'},
+        { class:'kwic-context text-xs-right', align:"right", text:'... context', value:'head_text_last'},
         { class:'kwic-keyword-head no-overflow',align:'center', text:'keyword', value:'keyword.text'},
         { class:'kwic-context text-xs-left',align:'left', text:'context ...', value:'tail_text'},
         // ...this.useSentiment?[{text:"sentiment",value:'sentiment'}]:[]
@@ -241,7 +241,7 @@ export default {
           meta: [],
           // sentiment: 0,
           // these are for sorting context -purposes
-          reverse_head_text: '',
+          head_text_last: '',
           head_text: '',
           tail_text: ''
         };
@@ -295,10 +295,15 @@ export default {
             }
           }
         }
-
-        r.reverse_head_text = r.head_text.split("").reverse().join("");
+        r.head_text_last = (r
+          .head
+          // filter out elements that are not within the window
+          .filter(({ role }) => role === '')
+          .at(-1) || { text: '' })
+          .text.trim()
         C.push(r);
       }
+
       return C;
     },
     csvFileText(){

--- a/mmda-frontend/src/components/ConcordancesKeyword/ConcordancesKeywordKWIC.vue
+++ b/mmda-frontend/src/components/ConcordancesKeyword/ConcordancesKeywordKWIC.vue
@@ -259,12 +259,7 @@ export default {
               }
           }
         }
-        r.head_text_last = (r
-            .head
-            // filter out elements that are not within the window
-            .filter(({ role }) => role === '')
-            .at(-1) || { text: '' })
-            .text.trim()
+        r.head_text_last = (r.head.at(-1) || { text: '' }).text.trim()
         C.push(r);
       }
       return C;

--- a/mmda-frontend/src/components/ConcordancesKeyword/ConcordancesKeywordKWIC.vue
+++ b/mmda-frontend/src/components/ConcordancesKeyword/ConcordancesKeywordKWIC.vue
@@ -197,7 +197,7 @@ export default {
     headers () {
       return [
         { class:'kwic-id-head',text:'ID',value:'match_pos',align:'center'},
-        { class:'kwic-context text-xs-right', align:"right", text:'... context', value:'reverse_head_text'},
+        { class:'kwic-context text-xs-right', align:"right", text:'... context', value:'head_text_last'},
         { class:'kwic-keyword-head no-overflow',align:'center', text:'keyword', value:'keyword.text'},
         { class:'kwic-context text-xs-left',align:'left', text:'context ...', value:'tail_text'},
       ];
@@ -215,7 +215,7 @@ export default {
           tail: [],
           meta: [],
           // these are for sorting context -purposes
-          reverse_head_text: '',
+          head_text_last: '',
           head_text: '',
           tail_text: ''
         };
@@ -259,8 +259,12 @@ export default {
               }
           }
         }
-
-        r.reverse_head_text = r.head_text.split("").reverse().join("");
+        r.head_text_last = (r
+            .head
+            // filter out elements that are not within the window
+            .filter(({ role }) => role === '')
+            .at(-1) || { text: '' })
+            .text.trim()
         C.push(r);
       }
       return C;


### PR DESCRIPTION
Fixes #16 

The `value` for the column `… context` consists now solely of the last token of the context before the keyword. Thus the sorting is now based on this token instead of its very last letter(s).